### PR TITLE
Add support for unknown state

### DIFF
--- a/ReliableLockVirtualDevice.groovy
+++ b/ReliableLockVirtualDevice.groovy
@@ -107,13 +107,15 @@ def markAsUnlocked() {
 	sendEvent(name: "lock", value: "unlocked")
 }
 
+// Mark as unknown without sending the event back to the parent app.  Called when the physical lock has jammed or is dead, to prevent cyclical firings.
+def markAsUnknown(state) {
+    log "${device.displayName}.markAsUnknown(${state})"
+	
+	sendEvent(name: "lock", value: state)
+}
 
 def setBattery(val) {
     if (val != null) {
         sendEvent(name: "battery", value: val)
     }
 }
-
-
-
-

--- a/ReliableLocksInstance.groovy
+++ b/ReliableLocksInstance.groovy
@@ -230,12 +230,18 @@ def wrappedLockHandler(evt) {
 		reliableLock.markAsLocked()
         state.desiredLockState = "locked"
 	}
-	else {
+	else if(wrappedLock.currentValue("lock") == "unlocked"){
 		log "${wrappedLock.displayName}:unlocked detected"
 		log "${reliableLock.displayName}:setting unlocked"
 		reliableLock.markAsUnlocked()
         state.desiredLockState = "unlocked"
 	}
+	else{
+		log "${wrappedLock.displayName}:unknown state detected"
+		log "${reliableLock.displayName}:setting ${wrappedLock.currentValue('lock')}"
+		reliableLock.markAsUnknown(wrappedLock.currentValue("lock"))
+		state.desiredLockState = wrappedLock.currentValue("lock")
+    }
 }
 
 
@@ -268,5 +274,6 @@ def log(msg) {
 		log.debug(msg)	
 	}
 }
+
 
 


### PR DESCRIPTION
When the wrapped lock attempts to lock but gets jammed (at least for Yale locks), it reports its state as "unknown." This causes an inconsistency between the wrapped lock reporting "unknown" and the Reliable lock instance reporting "unlocked." This update will surface up to the Reliable lock the unknown state reported by the underlying wrapped lock for automations to catch and handle more gracefully, such as a notification of a jammed lock or a dashboard showing the correct status.